### PR TITLE
Bugfix: eval-opam-env default value is string, evalOpam is always false

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "ocaml-formatter.eval-opam-env": {
           "title": "Eval opam env before every run",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "description": "Evals opam env at every run if set to true."
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,8 +23,7 @@ function callOcamlFormatCommand(
   content: string,
   fileName: string,
   dir: string,
-  profile: string,
-  evalOpam: boolean = false
+  profile: string
 ): ocamlformatCallOutput {
   const out: ocamlformatCallOutput = { text: "", error: null };
   try {
@@ -32,6 +31,7 @@ function callOcamlFormatCommand(
 
     const settings = vscode.workspace.getConfiguration("ocaml-formatter");
     const ocamlformatPath = <string>settings.get("ocamlformat-path");
+    const evalOpam = settings.get("eval-opam-env");
 
     let command = "";
     if (evalOpam) {


### PR DESCRIPTION
related: https://github.com/badochov/ocamlformatter-vscode/issues/2