### PR TITLE
Profiles compact and sparse are now removed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,6 @@ import { execSync } from "child_process";
 const profiles = [
   "conventional",
   "janestreet",
-  "sparse",
-  "compact",
   "ocamlformat",
   "own",
 ];


### PR DESCRIPTION
In OCamlFormat v0.22.4, Profiles compact and sparse are removed.